### PR TITLE
fix: registrar endpoints de lectura en blueprint API

### DIFF
--- a/product_api_service/api/__init__.py
+++ b/product_api_service/api/__init__.py
@@ -5,3 +5,7 @@ service_api = Blueprint("api", __name__, url_prefix="/api")
 from product_api_service.api.altaProduct import altaProductBP as _altaProductBP
 
 service_api.register_blueprint(_altaProductBP)
+
+from product_api_service.api.producto_leer import product_read_bp as _product_read_bp
+
+service_api.register_blueprint(_product_read_bp)


### PR DESCRIPTION
Me faltó registrar la blueprint de endpoints de lectura.