### PR TITLE
refactor: endpoint /eliminar de POST json a variable URL

### DIFF
--- a/product_api_service/api/blueprint_elim.py
+++ b/product_api_service/api/blueprint_elim.py
@@ -7,10 +7,9 @@ from product_api_service.database.session import create_local_session
 blueprint_eliminar = Blueprint("productos", __name__, url_prefix="/producto")
 
 #endpoint "eliminar producto"
-@blueprint_eliminar.route('/eliminar', methods=["POST"])
-def eliminar_producto():
-    data=request.json
-    id_producto=data.get('id')
+@blueprint_eliminar.route('/eliminar/<id_producto>', methods=["POST"])
+def eliminar_producto(id_producto):
+    
     if id_producto is not None:
         with create_local_session() as db:
             try:


### PR DESCRIPTION
Previamente el endpoint eliminar recibia un JSON donde se indicaba la ID del producto a eliminar, esto se reemplazo por una url variable cuya ultima parte es la id del producto a eliminar.