### PR TITLE
fix: permitir ausencia de imagen en form actualizar

### DIFF
--- a/product_api_service/api/api_update.py
+++ b/product_api_service/api/api_update.py
@@ -27,7 +27,7 @@ def update_existingProduct():
         imagen = UpdateFiles["filename"]
         new_image: bool = True
 
-    if imagen.filename and new_image:  # Verificar si el nombre del archivo está vacío
+    if new_image and imagen.filename :  # Verificar si el nombre del archivo está vacío
         UpdateRequest["img_orig_name"] = imagen.filename
 
     # validar info

--- a/product_api_service/schemas/product.py
+++ b/product_api_service/schemas/product.py
@@ -7,5 +7,4 @@ class Producto(BaseModel):
     img_rand_name: str | None = Field(min_length=1, max_length=36, default=None)
     precio: PositiveInt
     existencias: PositiveInt
-    img_orig_name: str = Field(min_length=1, max_length=100)
-    img_rand_name: str = Field(min_length=1, max_length=36)
+    img_orig_name: str | None  = Field(min_length=1, max_length=100, default=None)


### PR DESCRIPTION
Un campo de schema.Producto estaba repetido (img_rand_name) y tenía una previa que lo forzaba a ser un campo requerido, se elimino dicha línea y se cambió el campo de nombre original de imagen para permitir que las actualizaciones de Productos no requieran una nueva foto todo el tiempo.