### PR TITLE
fix: retornar etiquetas con cero productos en /leer/

### DIFF
--- a/product_api_service/api/leer_etiqueta.py
+++ b/product_api_service/api/leer_etiqueta.py
@@ -69,7 +69,11 @@ def read_all():
                 func.count(models.Producto.id),
             )
             .select_from(models.Etiqueta)
-            .join(models.Producto, models.Etiqueta.id == models.Producto.id_etiqueta)
+            .join(
+                models.Producto,
+                models.Etiqueta.id == models.Producto.id_etiqueta,
+                isouter=True,
+            )
             .group_by(models.Etiqueta.id, models.Etiqueta.nombre)
         )
 


### PR DESCRIPTION
Previamente el endpoint de lectura de todas las etiquetas solo retornaba etiquetas que tuviesen uno o mas productos, lo que evitaba que las etiquetas pudiesen ser utilizadas si no cuentan con productos. Solucionado al cambiar el INNER JOIN a OUTER